### PR TITLE
Fix Quill not exposed

### DIFF
--- a/script.js
+++ b/script.js
@@ -750,6 +750,26 @@ window.onload = async function() {
             ]
         }
     });
+    // expose globally for plugins like template manager/resource manager
+    window.quill = quill;
+
+    // basic handler for inserting images when the toolbar image button is clicked
+    quill.getModule('toolbar').addHandler('image', () => {
+        const input = document.createElement('input');
+        input.setAttribute('type', 'file');
+        input.setAttribute('accept', 'image/*');
+        input.addEventListener('change', () => {
+            const file = input.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const range = quill.getSelection();
+                quill.insertEmbed(range ? range.index : quill.getLength(), 'image', e.target.result);
+            };
+            reader.readAsDataURL(file);
+        });
+        input.click();
+    });
 
     document.getElementById("quillEditorContainer").style.display = "none";
     document.getElementById("preview").style.display = "block";


### PR DESCRIPTION
## Summary
- initialize Quill and store it on `window` so plugins can use it
- add built-in handler for inserting images from the toolbar

## Testing
- `npm test`
- `node server.js` *(start server)*

------
https://chatgpt.com/codex/tasks/task_e_686e73cf2fac833285d19b140c691500